### PR TITLE
Update copyright year to 2019

### DIFF
--- a/src/Components/Footer/index.jsx
+++ b/src/Components/Footer/index.jsx
@@ -4,7 +4,7 @@ class Footer extends React.Component {
   render() {
     return (
       <footer>
-        <div className="copyright">Copyright &copy; 2018 - The Bastion Bot Project</div>
+        <div className="copyright">Copyright &copy; 2019 - The Bastion Bot Project</div>
       </footer>
     );
   }


### PR DESCRIPTION
Hi there,

I just noticed that the copyright year is 2018 in the Bastion Embed Builder.

Here you go!

Kind regards,
Casper.